### PR TITLE
Fix parameter substitution

### DIFF
--- a/05_nested-stacks/internet-access.yml
+++ b/05_nested-stacks/internet-access.yml
@@ -29,7 +29,7 @@ Resources:
     Type: AWS::EC2::VPCGatewayAttachment
     Properties:
       InternetGatewayId: !Ref InternetGateway
-      VpcId: !Sub VpcId
+      VpcId: !Ref VpcId
 
   # Traffic must be explicitly routed through the internet gateway for bidirectional internet communication
   publicRouteTable:

--- a/05_nested-stacks/internet-access.yml
+++ b/05_nested-stacks/internet-access.yml
@@ -29,7 +29,7 @@ Resources:
     Type: AWS::EC2::VPCGatewayAttachment
     Properties:
       InternetGatewayId: !Ref InternetGateway
-      VpcId: !Sub ${NetworkStack}-VpcId
+      VpcId: !Sub VpcId
 
   # Traffic must be explicitly routed through the internet gateway for bidirectional internet communication
   publicRouteTable:


### PR DESCRIPTION
The parameter name was updated in an example to combine cross stack
references and nested stacks that shouldn't have been committed to the
repository.